### PR TITLE
minor tweaks to formatting

### DIFF
--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -35,10 +35,11 @@ void Corpus::toYaml() {
   std::cout << "library: \"" << library << "\"\nlocations: " << std::endl;
 
   for (auto &f : functions) {
-    std::cout << "- function: " << f.function_name << "\n  parameters:";
+    std::cout << "  - function:\n      name: " << f.function_name << "\n      parameters:";
     for (auto const &p : f.parameters) {
-      std::cout << "\n    - name: " << p.name << "\n      type: " << p.type
-                << "\n      location: " << p.location << "\n      direction: " << p.direction;
+      std::cout << "\n        - name: " << p.name << "\n          type: " << p.type
+                << "\n          location: " << p.location
+                << "\n          direction: " << p.direction;
     }
     std::cout << std::endl;
   }
@@ -59,9 +60,9 @@ void Corpus::toJson() {
       endcomma = ",";
     }
     std::cout << "   {\n"
-              << "    \"function\": \"" << f.function_name << ",\n"
-              << "    \"parameters\":\n"
-              << "    [\n";
+              << "    \"function\": {\n"
+              << "      \"name\": \"" << f.function_name << ",\n"
+              << "      \"parameters\": [\n";
 
     for (auto const &p : f.parameters) {
       // Check if we are at the last entry (no comma) or not

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -322,9 +322,7 @@ namespace smeagle::x86_64 {
           break;
         }
         // Greater than 6 is stored in memory
-        default: {
-          regString = "memory";
-        }
+        default: { regString = "memory"; }
       }
     }
 

--- a/source/detail/parser/x86_64.hpp
+++ b/source/detail/parser/x86_64.hpp
@@ -12,6 +12,6 @@
 
 namespace smeagle::x86_64 {
 
-  std::vector<parameter> parse_parameters(Dyninst::SymtabAPI::Symbol *symbol);
+  std::vector<parameter> parse_parameters(Dyninst::SymtabAPI::Symbol* symbol);
   parameter parse_return_value(Dyninst::SymtabAPI::Symbol const* symbol);
 }  // namespace smeagle::x86_64


### PR DESCRIPTION
I tweaked the structure of the output and made sure it was valid yaml, and with this change it looks like:

```yaml
library: "libtcl8.6.so"
locations: 
  - function:
      name: Tcl_CreateNamespace
      parameters:
        - name: interp
          type: Tcl_Interp *
          location: framebase+8
          direction: unknown
        - name: name
          type: const char *
          location: framebase+16
          direction: import
        - name: clientData
          type: ClientData
          location: framebase+24
          direction: import
        - name: deleteProc
          type: Tcl_NamespaceDeleteProc *
          location: framebase+24
          direction: unknown
  - function:
      name: Tcl_Backslash
      parameters:
        - name: src
          type: const char *
          location: framebase+8
          direction: import
        - name: readPtr
          type: int *
          location: framebase+16
          direction: import
...  
```
I also updated the json to reflect this change. basically - function is at the top level, and has attributes for parameters and name.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>